### PR TITLE
SPM build support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,9 +14,8 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(name: "Swifter",
-                 url: "git@github.com:httpswift/swifter.git",
-                 from: "1.5.0"),
+        .package(url: "git@github.com:apple/swift-nio.git",
+                 from: "2.22.1"),
         .package(name: "Mustache",
                  url: "git@github.com:groue/GRMustache.swift.git",
                  from: "4.0.0")
@@ -26,7 +25,11 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "Shock",
-            dependencies: ["Swifter", "Mustache"],
+            dependencies: [
+                .product(name: "NIO", package: "swift-nio"),
+                .product(name: "NIOHTTP1", package: "swift-nio"),
+                "Mustache"
+            ],
             path: "Shock/Classes/"),
         .testTarget(
             name: "Shock-Tests",

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,36 @@
+// swift-tools-version:5.2
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "Shock",
+    products: [
+        // Products define the executables and libraries produced by a package, and make them visible to other packages.
+        .library(
+            name: "Shock",
+            targets: ["Shock"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+        .package(name: "Swifter",
+                 url: "git@github.com:httpswift/swifter.git",
+                 from: "1.5.0"),
+        .package(name: "Mustache",
+                 url: "git@github.com:groue/GRMustache.swift.git",
+                 from: "4.0.0")
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
+        .target(
+            name: "Shock",
+            dependencies: ["Swifter", "Mustache"],
+            path: "Shock/Classes/"),
+        .testTarget(
+            name: "Shock-Tests",
+            dependencies: ["Shock"],
+            path: "Example/Tests"),
+    ]
+)


### PR DESCRIPTION
Adds SPM support.

NOTE: Tests don't function yet but this is because you have two choices w.r.t resources:

1.    **Swift Version <= 5.2** Do crazy copying of files into different locations, and/or restructure files in project, and add lots of custom code into the main library for loading resources from filesystem (vs bundle)
 2.   **Swift Version >= 5.3** Add a resources parameter to the target and point it at the resources.

So, yeah, option 2 obviously! (Which means waiting until Xcode 12 has wide adoption)